### PR TITLE
local and remote providers can be used seamlessly

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,21 +118,16 @@ I would like to express our gratitude to the following projects, libraries, and 
   - [MobX-State-Tree](https://mobx-state-tree.js.org/) - State management solution
   - [OpenAI SDK](https://github.com/openai/openai-node) - Client for AI model integration
   - [Vitest](https://vitest.dev/) - Testing framework
-  - [mlx-omni-server](https://github.com/seemueller-io/mlx-omni-server) - Local inference server for Apple Silicon
   - [OpenAI](https://github.com/openai) 
   - [Groq](https://console.groq.com/) - Fast inference API
   - [Anthropic](https://www.anthropic.com/) - Creator of Claude models
   - [Fireworks](https://fireworks.ai/) - AI inference platform
   - [XAI](https://x.ai/) - Creator of Grok models
   - [Cerebras](https://www.cerebras.net/) - AI compute and models
-  - [Ollama](https://github.com/ollama/ollama) - Local model running
   - [(madroidmaq) MLX Omni Server](https://github.com/madroidmaq/mlx-omni-server) - Open-source high-performance inference for Apple Silicon
+  - [MLX](https://github.com/ml-explore/mlx) - An array framework for Apple silicon
+  - [Ollama](https://github.com/ollama/ollama) - Versatile solution for self-hosting models 
 
-- **Contributors**
-  - All the developers who have contributed code, reported issues, or provided feedback
-
-- **Open Source Community**
-  - The broader open-source community for creating and maintaining the tools and libraries that make this project possible
 
 ## License
 ~~~text

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ This is a full-stack Conversational AI. It runs on Cloudflare or Bun.
 
 
 ## Local Inference
-> Local inference is achieved by overriding the `OPENAI_API_KEY` and `OPENAI_API_ENDPOINT` environment variables. See below.
+> Local inference is supported for Ollama and mlx-omni-server. OpenAI compatible servers can be used by overriding OPENAI_API_KEY and OPENAI_API_ENDPOINT. 
 
 ### mlx-omni-server
-(default) (Apple Silicon Only) - Use Ollama for other platforms.
+(default) (Apple Silicon Only)
 ~~~bash
 # (prereq) install mlx-omni-server
 brew tap seemueller-io/tap                   

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "clean": "packages/scripts/cleanup.sh",
-    "test:all": "bunx vitest",
+    "test:all": "bun run --filter='*' tests",
     "client:dev": "(cd packages/client && bun run dev)",
     "server:dev": "bun build:client && (cd packages/server && bun run dev)",
     "build": "(cd packages/cloudflare-workers && bun run deploy:dry-run)",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "clean": "packages/scripts/cleanup.sh",
-    "test:all": "bun run --filter='*' tests",
+    "test:all": "bunx vitest",
     "client:dev": "(cd packages/client && bun run dev)",
     "server:dev": "bun build:client && (cd packages/server && bun run dev)",
     "build": "(cd packages/cloudflare-workers && bun run deploy:dry-run)",

--- a/packages/client/src/components/chat/input-menu/InputMenu.tsx
+++ b/packages/client/src/components/chat/input-menu/InputMenu.tsx
@@ -1,215 +1,197 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {useCallback, useEffect, useRef, useState} from "react";
 import {
-  Box,
-  Button,
-  Divider,
-  Flex,
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  Text,
-  useDisclosure,
-  useOutsideClick,
+    Box,
+    Button,
+    Divider,
+    Flex,
+    IconButton,
+    Menu,
+    MenuButton,
+    MenuItem,
+    MenuList,
+    Text,
+    useDisclosure,
+    useOutsideClick,
 } from "@chakra-ui/react";
-import { observer } from "mobx-react-lite";
-import { ChevronDown, Copy, RefreshCcw, Settings } from "lucide-react";
-import ClientChatStore from "../../../stores/ClientChatStore";
+import {observer} from "mobx-react-lite";
+import {ChevronDown, Copy, RefreshCcw, Settings} from "lucide-react";
 import clientChatStore from "../../../stores/ClientChatStore";
 import FlyoutSubMenu from "./FlyoutSubMenu";
-import { useIsMobile } from "../../contexts/MobileContext";
-import { useIsMobile as useIsMobileUserAgent } from "../../../hooks/_IsMobileHook";
-import { getModelFamily, SUPPORTED_MODELS } from "../lib/SupportedModels";
-import { formatConversationMarkdown } from "../lib/exportConversationAsMarkdown";
+import {useIsMobile} from "../../contexts/MobileContext";
+import {useIsMobile as useIsMobileUserAgent} from "../../../hooks/_IsMobileHook";
+import {formatConversationMarkdown} from "../lib/exportConversationAsMarkdown";
 
 export const MsM_commonButtonStyles = {
-  bg: "transparent",
-  color: "text.primary",
-  borderRadius: "full",
-  padding: 2,
-  border: "none",
-  _hover: { bg: "rgba(255, 255, 255, 0.2)" },
-  _active: { bg: "rgba(255, 255, 255, 0.3)" },
-  _focus: { boxShadow: "none" },
+    bg: "transparent",
+    color: "text.primary",
+    borderRadius: "full",
+    padding: 2,
+    border: "none",
+    _hover: {bg: "rgba(255, 255, 255, 0.2)"},
+    _active: {bg: "rgba(255, 255, 255, 0.3)"},
+    _focus: {boxShadow: "none"},
 };
 
 const InputMenu: React.FC<{ isDisabled?: boolean }> = observer(
-  ({ isDisabled }) => {
-    const isMobile = useIsMobile();
-    const isMobileUserAgent = useIsMobileUserAgent();
-    const {
-      isOpen,
-      onOpen,
-      onClose,
-      onToggle,
-      getDisclosureProps,
-      getButtonProps,
-    } = useDisclosure();
+    ({isDisabled}) => {
+        const isMobile = useIsMobile();
+        const isMobileUserAgent = useIsMobileUserAgent();
+        const {
+            isOpen,
+            onOpen,
+            onClose,
+            onToggle,
+            getDisclosureProps,
+            getButtonProps,
+        } = useDisclosure();
 
-    const [controlledOpen, setControlledOpen] = useState<boolean>(false);
+        const [controlledOpen, setControlledOpen] = useState<boolean>(false);
+        const [supportedModels, setSupportedModels] = useState<any[]>([]);
 
-    useEffect(() => {
-      setControlledOpen(isOpen);
-    }, [isOpen]);
+        useEffect(() => {
+            setControlledOpen(isOpen);
+        }, [isOpen]);
+
+        useEffect(() => {
+            fetch("/api/models").then(response => response.json()).then((models) => {
+                setSupportedModels(models);
+            }).catch((err) => {
+                console.error("Could not fetch models: ", err);
+            });
+        }, []);
 
 
-    const getSupportedModels = async () => {
-        // Check if fetch is available (browser environment)
-        if (typeof fetch !== 'undefined') {
-            try {
-                return await (await fetch("/api/models")).json();
-            } catch (error) {
-                console.error("Error fetching models:", error);
-                return [];
-            }
-        } else {
-            // In test environment or where fetch is not available
-            console.log("Fetch not available, using default models");
-            return [];
+        const handleClose = useCallback(() => {
+            onClose();
+        }, [isOpen]);
+
+        const handleCopyConversation = useCallback(() => {
+            navigator.clipboard
+                .writeText(formatConversationMarkdown(clientChatStore.items))
+                .then(() => {
+                    window.alert(
+                        "Conversation copied to clipboard. \n\nPaste it somewhere safe!",
+                    );
+                    onClose();
+                })
+                .catch((err) => {
+                    console.error("Could not copy text to clipboard: ", err);
+                    window.alert("Failed to copy conversation. Please try again.");
+                });
+        }, [onClose]);
+
+        async function selectModelFn({name, value}) {
+            clientChatStore.setModel(value);
         }
-    }
 
-      useEffect(() => {
-           getSupportedModels().then((supportedModels) => {
-               // Check if setSupportedModels method exists before calling it
-               if (clientChatStore.setSupportedModels) {
-                   clientChatStore.setSupportedModels(supportedModels);
-               } else {
-                   console.log("setSupportedModels method not available in this environment");
-               }
-           });
-      }, []);
+        function isSelectedModelFn({name, value}) {
+            return clientChatStore.model === value;
+        }
 
+        const menuRef = useRef();
+        const [menuState, setMenuState] = useState();
 
-    const handleClose = useCallback(() => {
-      onClose();
-    }, [isOpen]);
-
-    const handleCopyConversation = useCallback(() => {
-      navigator.clipboard
-        .writeText(formatConversationMarkdown(clientChatStore.items))
-        .then(() => {
-          window.alert(
-            "Conversation copied to clipboard. \n\nPaste it somewhere safe!",
-          );
-          onClose();
-        })
-        .catch((err) => {
-          console.error("Could not copy text to clipboard: ", err);
-          window.alert("Failed to copy conversation. Please try again.");
+        useOutsideClick({
+            enabled: !isMobile && isOpen,
+            ref: menuRef,
+            handler: () => {
+                handleClose();
+            },
         });
-    }, [onClose]);
 
-    async function selectModelFn({ name, value }) {
-        clientChatStore.setModel(value);
-    }
-
-    function isSelectedModelFn({ name, value }) {
-      return clientChatStore.model === value;
-    }
-
-    const menuRef = useRef();
-    const [menuState, setMenuState] = useState();
-
-    useOutsideClick({
-      enabled: !isMobile && isOpen,
-      ref: menuRef,
-      handler: () => {
-        handleClose();
-      },
-    });
-
-    return (
-      <Menu
-        isOpen={controlledOpen}
-        onClose={onClose}
-        onOpen={onOpen}
-        autoSelect={false}
-        closeOnSelect={false}
-        closeOnBlur={isOpen && !isMobileUserAgent}
-        isLazy={true}
-        lazyBehavior={"unmount"}
-      >
-        {isMobile ? (
-          <MenuButton
-            as={IconButton}
-            bg="text.accent"
-            icon={<Settings size={20} />}
-            isDisabled={isDisabled}
-            aria-label="Settings"
-            _hover={{ bg: "rgba(255, 255, 255, 0.2)" }}
-            _focus={{ boxShadow: "none" }}
-            {...MsM_commonButtonStyles}
-          />
-        ) : (
-          <MenuButton
-            as={Button}
-            rightIcon={<ChevronDown size={16} />}
-            isDisabled={isDisabled}
-            variant="ghost"
-            display="flex"
-            justifyContent="space-between"
-            alignItems="center"
-            minW="auto"
-            {...MsM_commonButtonStyles}
-          >
-            <Text noOfLines={1} maxW="100px" fontSize="sm">
-              {clientChatStore.model}
-            </Text>
-          </MenuButton>
-        )}
-        <MenuList
-          bg="background.tertiary"
-          border="none"
-          borderRadius="md"
-          boxShadow="lg"
-          minW={"10rem"}
-          ref={menuRef}
-        >
-          <FlyoutSubMenu
-            title="Text Models"
-            flyoutMenuOptions={clientChatStore.supportedModels.map((m) => ({ name: m, value: m }))}
-            onClose={onClose}
-            parentIsOpen={isOpen}
-            setMenuState={setMenuState}
-            handleSelect={selectModelFn}
-            isSelected={isSelectedModelFn}
-          />
-          <Divider color="text.tertiary" />
-          {/*Export conversation button*/}
-          <MenuItem
-            bg="background.tertiary"
-            color="text.primary"
-            onClick={handleCopyConversation}
-            _hover={{ bg: "rgba(0, 0, 0, 0.05)" }}
-            _focus={{ bg: "rgba(0, 0, 0, 0.1)" }}
-          >
-            <Flex align="center">
-              <Copy size="16px" style={{ marginRight: "8px" }} />
-              <Box>Export</Box>
-            </Flex>
-          </MenuItem>
-          {/*New conversation button*/}
-          <MenuItem
-            bg="background.tertiary"
-            color="text.primary"
-            onClick={() => {
-              clientChatStore.setActiveConversation("conversation:new");
-              onClose();
-            }}
-            _hover={{ bg: "rgba(0, 0, 0, 0.05)" }}
-            _focus={{ bg: "rgba(0, 0, 0, 0.1)" }}
-          >
-            <Flex align="center">
-              <RefreshCcw size="16px" style={{ marginRight: "8px" }} />
-              <Box>New</Box>
-            </Flex>
-          </MenuItem>
-        </MenuList>
-      </Menu>
-    );
-  },
+        return (
+            <Menu
+                isOpen={controlledOpen}
+                onClose={onClose}
+                onOpen={onOpen}
+                autoSelect={false}
+                closeOnSelect={false}
+                closeOnBlur={isOpen && !isMobileUserAgent}
+                isLazy={true}
+                lazyBehavior={"unmount"}
+            >
+                {isMobile ? (
+                    <MenuButton
+                        as={IconButton}
+                        bg="text.accent"
+                        icon={<Settings size={20}/>}
+                        isDisabled={isDisabled}
+                        aria-label="Settings"
+                        _hover={{bg: "rgba(255, 255, 255, 0.2)"}}
+                        _focus={{boxShadow: "none"}}
+                        {...MsM_commonButtonStyles}
+                    />
+                ) : (
+                    <MenuButton
+                        as={Button}
+                        rightIcon={<ChevronDown size={16}/>}
+                        isDisabled={isDisabled}
+                        variant="ghost"
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                        minW="auto"
+                        {...MsM_commonButtonStyles}
+                    >
+                        <Text noOfLines={1} maxW="100px" fontSize="sm">
+                            {clientChatStore.model}
+                        </Text>
+                    </MenuButton>
+                )}
+                <MenuList
+                    bg="background.tertiary"
+                    border="none"
+                    borderRadius="md"
+                    boxShadow="lg"
+                    minW={"10rem"}
+                    ref={menuRef}
+                >
+                    <FlyoutSubMenu
+                        title="Text Models"
+                        flyoutMenuOptions={supportedModels.map((modelData) => ({
+                            name: modelData.id.split('/').pop() || modelData.id,
+                            value: modelData.id
+                        }))}
+                        onClose={onClose}
+                        parentIsOpen={isOpen}
+                        setMenuState={setMenuState}
+                        handleSelect={selectModelFn}
+                        isSelected={isSelectedModelFn}
+                    />
+                    <Divider color="text.tertiary"/>
+                    {/*Export conversation button*/}
+                    <MenuItem
+                        bg="background.tertiary"
+                        color="text.primary"
+                        onClick={handleCopyConversation}
+                        _hover={{bg: "rgba(0, 0, 0, 0.05)"}}
+                        _focus={{bg: "rgba(0, 0, 0, 0.1)"}}
+                    >
+                        <Flex align="center">
+                            <Copy size="16px" style={{marginRight: "8px"}}/>
+                            <Box>Export</Box>
+                        </Flex>
+                    </MenuItem>
+                    {/*New conversation button*/}
+                    <MenuItem
+                        bg="background.tertiary"
+                        color="text.primary"
+                        onClick={() => {
+                            clientChatStore.setActiveConversation("conversation:new");
+                            onClose();
+                        }}
+                        _hover={{bg: "rgba(0, 0, 0, 0.05)"}}
+                        _focus={{bg: "rgba(0, 0, 0, 0.1)"}}
+                    >
+                        <Flex align="center">
+                            <RefreshCcw size="16px" style={{marginRight: "8px"}}/>
+                            <Box>New</Box>
+                        </Flex>
+                    </MenuItem>
+                </MenuList>
+            </Menu>
+        );
+    },
 );
 
 export default InputMenu;

--- a/packages/server/lib/chat-sdk.ts
+++ b/packages/server/lib/chat-sdk.ts
@@ -1,8 +1,8 @@
 import {OpenAI} from "openai";
 import Message from "../models/Message.ts";
 import {AssistantSdk} from "./assistant-sdk.ts";
-import {getModelFamily} from "@open-gsio/ai/supported-models.ts";
 import type {Instance} from "mobx-state-tree";
+import {ProviderRepository} from "../providers/_ProviderRepository";
 
 export class ChatSdk {
     static async preprocess({
@@ -95,9 +95,10 @@ export class ChatSdk {
             assistantPrompt: string;
             toolResults: Instance<typeof Message>;
             model: any;
+            env: Env;
         },
     ) {
-        const modelFamily = getModelFamily(opts.model);
+        const modelFamily = ProviderRepository.getModelFamily(opts.model, opts.env)
 
         const messagesToSend = [];
 

--- a/packages/server/lib/chat-sdk.ts
+++ b/packages/server/lib/chat-sdk.ts
@@ -88,7 +88,7 @@ export class ChatSdk {
         });
     }
 
-    static buildMessageChain(
+    static async buildMessageChain(
         messages: any[],
         opts: {
             systemPrompt: any;
@@ -98,7 +98,7 @@ export class ChatSdk {
             env: Env;
         },
     ) {
-        const modelFamily = ProviderRepository.getModelFamily(opts.model, opts.env)
+        const modelFamily = await ProviderRepository.getModelFamily(opts.model, opts.env)
 
         const messagesToSend = [];
 

--- a/packages/server/providers/_ProviderRepository.ts
+++ b/packages/server/providers/_ProviderRepository.ts
@@ -1,0 +1,76 @@
+
+export class ProviderRepository {
+    #providers: {name: string, key: string, endpoint: string}[] = [];
+    constructor(env: Record<string, any>) {
+        this.setProviders(env);
+    }
+
+    static OPENAI_COMPAT_ENDPOINTS = {
+        xai: 'https://api.x.ai/v1',
+        groq: 'https://api.groq.com/openai/v1',
+        google: 'https://generativelanguage.googleapis.com/v1beta/openai',
+        fireworks: 'https://api.fireworks.ai/inference/v1',
+        cohere: 'https://api.cohere.ai/compatibility/v1',
+        cloudflare: 'https://api.cloudflare.com/client/v4/accounts/{CLOUDFLARE_ACCOUNT_ID}/ai/v1',
+        anthropic: 'https://api.anthropic.com/v1/',
+        openai: 'https://api.openai.com/v1/',
+        cerebras: 'https://api.cerebras.com/v1/',
+        ollama: "http://localhost:11434",
+        mlx: "http://localhost:10240",
+    }
+
+    static async getModelFamily(model, env: Env) {
+        const allModels = await env.KV_STORAGE.get("supportedModels");
+        const models = JSON.parse(allModels);
+        const modelData = models.filter(m => m.id === model)
+        console.log({modelData})
+        return modelData[0].provider;
+    }
+
+    static async getModelMeta(meta, env) {
+        const allModels = await env.KV_STORAGE.get("supportedModels");
+        const models = JSON.parse(allModels);
+        return models.filter(m => m.id === meta.model).pop()
+    }
+
+    getProviders():  {name: string, key: string, endpoint: string}[] {
+        return this.#providers;
+    }
+
+    setProviders(env: Record<string, any>) {
+        let envKeys = Object.keys(env);
+        for (let i = 0; i < envKeys.length; i++) {
+            if (envKeys[i].endsWith('KEY')) {
+                const detectedProvider = envKeys[i].split('_')[0].toLowerCase();
+                switch (detectedProvider) {
+                    case 'anthropic':
+                        this.#providers.push({
+                            name: 'anthropic',
+                            key: env.ANTHROPIC_API_KEY,
+                            endpoint: OPENAI_COMPAT_ENDPOINTS['anthropic']
+                        });
+                        break;
+                    case 'gemini':
+                        this.#providers.push({
+                            name: 'google',
+                            key: env.GEMINI_API_KEY,
+                            endpoint: OPENAI_COMPAT_ENDPOINTS['google']
+                        });
+                        break;
+                    case 'cloudflare':
+                        this.#providers.push({
+                            name: 'cloudflare',
+                            key: env.CLOUDFLARE_API_KEY,
+                            endpoint: OPENAI_COMPAT_ENDPOINTS[detectedProvider].replace("{CLOUDFLARE_ACCOUNT_ID}", env.CLOUDFLARE_ACCOUNT_ID)
+                        })
+                    default:
+                        this.#providers.push({
+                            name: detectedProvider,
+                            key: env[envKeys[i]],
+                            endpoint: OPENAI_COMPAT_ENDPOINTS[detectedProvider]
+                        });
+                }
+            }
+        }
+    }
+}

--- a/packages/server/providers/_ProviderRepository.ts
+++ b/packages/server/providers/_ProviderRepository.ts
@@ -47,27 +47,27 @@ export class ProviderRepository {
                         this.#providers.push({
                             name: 'anthropic',
                             key: env.ANTHROPIC_API_KEY,
-                            endpoint: OPENAI_COMPAT_ENDPOINTS['anthropic']
+                            endpoint: ProviderRepository.OPENAI_COMPAT_ENDPOINTS['anthropic']
                         });
                         break;
                     case 'gemini':
                         this.#providers.push({
                             name: 'google',
                             key: env.GEMINI_API_KEY,
-                            endpoint: OPENAI_COMPAT_ENDPOINTS['google']
+                            endpoint: ProviderRepository.OPENAI_COMPAT_ENDPOINTS['google']
                         });
                         break;
                     case 'cloudflare':
                         this.#providers.push({
                             name: 'cloudflare',
                             key: env.CLOUDFLARE_API_KEY,
-                            endpoint: OPENAI_COMPAT_ENDPOINTS[detectedProvider].replace("{CLOUDFLARE_ACCOUNT_ID}", env.CLOUDFLARE_ACCOUNT_ID)
+                            endpoint: ProviderRepository.OPENAI_COMPAT_ENDPOINTS[detectedProvider].replace("{CLOUDFLARE_ACCOUNT_ID}", env.CLOUDFLARE_ACCOUNT_ID)
                         })
                     default:
                         this.#providers.push({
                             name: detectedProvider,
                             key: env[envKeys[i]],
-                            endpoint: OPENAI_COMPAT_ENDPOINTS[detectedProvider]
+                            endpoint: ProviderRepository.OPENAI_COMPAT_ENDPOINTS[detectedProvider]
                         });
                 }
             }

--- a/packages/server/providers/cerebras.ts
+++ b/packages/server/providers/cerebras.ts
@@ -1,10 +1,11 @@
 import {OpenAI} from "openai";
 import {BaseChatProvider, CommonProviderParams} from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class CerebrasChatProvider extends BaseChatProvider {
   getOpenAIClient(param: CommonProviderParams): OpenAI {
     return new OpenAI({
-      baseURL: "https://api.cerebras.ai/v1",
+      baseURL: ProviderRepository.OPENAI_COMPAT_ENDPOINTS.cerebras,
       apiKey: param.env.CEREBRAS_API_KEY,
     });
   }

--- a/packages/server/providers/chat-stream-provider.ts
+++ b/packages/server/providers/chat-stream-provider.ts
@@ -35,6 +35,7 @@ export abstract class BaseChatProvider implements ChatStreamProvider {
       model: param.model,
       assistantPrompt,
       toolResults: param.preprocessedContext,
+      env: param.env
     });
 
     const client = this.getOpenAIClient(param);

--- a/packages/server/providers/chat-stream-provider.ts
+++ b/packages/server/providers/chat-stream-provider.ts
@@ -30,7 +30,7 @@ export abstract class BaseChatProvider implements ChatStreamProvider {
     dataCallback: (data: any) => void,
   ) {
     const assistantPrompt = ChatSdk.buildAssistantPrompt({ maxTokens: param.maxTokens });
-    const safeMessages = ChatSdk.buildMessageChain(param.messages, {
+    const safeMessages = await ChatSdk.buildMessageChain(param.messages, {
       systemPrompt: param.systemPrompt,
       model: param.model,
       assistantPrompt,

--- a/packages/server/providers/claude.ts
+++ b/packages/server/providers/claude.ts
@@ -69,6 +69,7 @@ export class ClaudeChatProvider extends BaseChatProvider {
       model: param.model,
       assistantPrompt,
       toolResults: param.preprocessedContext,
+      env: param.env,
     });
 
     const streamParams = this.getStreamParams(param, safeMessages);

--- a/packages/server/providers/cloudflareAi.ts
+++ b/packages/server/providers/cloudflareAi.ts
@@ -1,13 +1,12 @@
 import {OpenAI} from "openai";
 import {BaseChatProvider, CommonProviderParams} from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class CloudflareAiChatProvider extends BaseChatProvider {
   getOpenAIClient(param: CommonProviderParams): OpenAI {
-    const cfAiURL = `https://api.cloudflare.com/client/v4/accounts/${param.env.CLOUDFLARE_ACCOUNT_ID}/ai/v1`;
-
     return new OpenAI({
       apiKey: param.env.CLOUDFLARE_API_KEY,
-      baseURL: cfAiURL,
+      baseURL: ProviderRepository.OPENAI_COMPAT_ENDPOINTS.cloudflare.replace("{CLOUDFLARE_ACCOUNT_ID}", param.env.CLOUDFLARE_ACCOUNT_ID),
     });
   }
 

--- a/packages/server/providers/fireworks.ts
+++ b/packages/server/providers/fireworks.ts
@@ -11,12 +11,13 @@ import {
 import Message from "../models/Message.ts";
 import ChatSdk from "../lib/chat-sdk.ts";
 import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class FireworksAiChatProvider extends BaseChatProvider {
   getOpenAIClient(param: CommonProviderParams): OpenAI {
     return new OpenAI({
       apiKey: param.env.FIREWORKS_API_KEY,
-      baseURL: "https://api.fireworks.ai/inference/v1",
+      baseURL: ProviderRepository.OPENAI_COMPAT_ENDPOINTS.fireworks,
     });
   }
 

--- a/packages/server/providers/google.ts
+++ b/packages/server/providers/google.ts
@@ -2,11 +2,12 @@ import { OpenAI } from "openai";
 import ChatSdk from "../lib/chat-sdk.ts";
 import { StreamParams } from "../services/ChatService.ts";
 import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class GoogleChatProvider extends BaseChatProvider {
   getOpenAIClient(param: CommonProviderParams): OpenAI {
     return new OpenAI({
-      baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+      baseURL: ProviderRepository.OPENAI_COMPAT_ENDPOINTS.google,
       apiKey: param.env.GEMINI_API_KEY,
     });
   }

--- a/packages/server/providers/groq.ts
+++ b/packages/server/providers/groq.ts
@@ -7,11 +7,12 @@ import {
   UnionStringArray,
 } from "mobx-state-tree";
 import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class GroqChatProvider extends BaseChatProvider {
   getOpenAIClient(param: CommonProviderParams): OpenAI {
     return new OpenAI({
-      baseURL: "https://api.groq.com/openai/v1",
+      baseURL: ProviderRepository.OPENAI_COMPAT_ENDPOINTS.groq,
       apiKey: param.env.GROQ_API_KEY,
     });
   }

--- a/packages/server/providers/mlx-omni.ts
+++ b/packages/server/providers/mlx-omni.ts
@@ -1,0 +1,73 @@
+import { OpenAI } from "openai";
+import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+
+export class MlxOmniChatProvider extends BaseChatProvider {
+    getOpenAIClient(param: CommonProviderParams): OpenAI {
+        return new OpenAI({
+            baseURL: param.env.MLX_API_ENDPOINT ?? "http://localhost:10240",
+            apiKey: param.env.MLX_API_KEY,
+        });
+    }
+
+    getStreamParams(param: CommonProviderParams, safeMessages: any[]): any {
+        const tuningParams = {
+            temperature: 0.75,
+        };
+
+        const getTuningParams = () => {
+            return tuningParams;
+        };
+
+        return {
+            model: param.model,
+            messages: safeMessages,
+            stream: true,
+            ...getTuningParams(),
+        };
+    }
+
+    async processChunk(chunk: any, dataCallback: (data: any) => void): Promise<boolean> {
+        if (chunk.choices && chunk.choices[0]?.finish_reason === "stop") {
+            dataCallback({ type: "chat", data: chunk });
+            return true;
+        }
+
+        dataCallback({ type: "chat", data: chunk });
+        return false;
+    }
+}
+
+export class MlxOmniChatSdk {
+    private static provider = new MlxOmniChatProvider();
+
+    static async handleMlxOmniStream(
+        ctx: {
+            openai: OpenAI;
+            systemPrompt: any;
+            preprocessedContext: any;
+            maxTokens: unknown | number | undefined;
+            messages: any;
+            disableWebhookGeneration: boolean;
+            model: any;
+            env: Env;
+        },
+        dataCallback: (data: any) => any,
+    ) {
+        if (!ctx.messages?.length) {
+            return new Response("No messages provided", { status: 400 });
+        }
+
+        return this.provider.handleStream(
+            {
+                systemPrompt: ctx.systemPrompt,
+                preprocessedContext: ctx.preprocessedContext,
+                maxTokens: ctx.maxTokens,
+                messages: ctx.messages,
+                model: ctx.model,
+                env: ctx.env,
+                disableWebhookGeneration: ctx.disableWebhookGeneration,
+            },
+            dataCallback,
+        );
+    }
+}

--- a/packages/server/providers/ollama.ts
+++ b/packages/server/providers/ollama.ts
@@ -1,10 +1,11 @@
 import { OpenAI } from "openai";
 import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+import {ProviderRepository} from "./_ProviderRepository";
 
 export class OllamaChatProvider extends BaseChatProvider {
     getOpenAIClient(param: CommonProviderParams): OpenAI {
         return new OpenAI({
-            baseURL: param.env.OLLAMA_API_ENDPOINT ?? ,
+            baseURL: param.env.OLLAMA_API_ENDPOINT ??  ProviderRepository.OPENAI_COMPAT_ENDPOINTS.ollama ,
             apiKey: param.env.OLLAMA_API_KEY,
         });
     }

--- a/packages/server/providers/ollama.ts
+++ b/packages/server/providers/ollama.ts
@@ -1,0 +1,73 @@
+import { OpenAI } from "openai";
+import { BaseChatProvider, CommonProviderParams } from "./chat-stream-provider.ts";
+
+export class OllamaChatProvider extends BaseChatProvider {
+    getOpenAIClient(param: CommonProviderParams): OpenAI {
+        return new OpenAI({
+            baseURL: param.env.OLLAMA_API_ENDPOINT ?? ,
+            apiKey: param.env.OLLAMA_API_KEY,
+        });
+    }
+
+    getStreamParams(param: CommonProviderParams, safeMessages: any[]): any {
+        const tuningParams = {
+            temperature: 0.75,
+        };
+
+        const getTuningParams = () => {
+            return tuningParams;
+        };
+
+        return {
+            model: param.model,
+            messages: safeMessages,
+            stream: true,
+            ...getTuningParams(),
+        };
+    }
+
+    async processChunk(chunk: any, dataCallback: (data: any) => void): Promise<boolean> {
+        if (chunk.choices && chunk.choices[0]?.finish_reason === "stop") {
+            dataCallback({ type: "chat", data: chunk });
+            return true;
+        }
+
+        dataCallback({ type: "chat", data: chunk });
+        return false;
+    }
+}
+
+export class OllamaChatSdk {
+    private static provider = new OllamaChatProvider();
+
+    static async handleOllamaStream(
+        ctx: {
+            openai: OpenAI;
+            systemPrompt: any;
+            preprocessedContext: any;
+            maxTokens: unknown | number | undefined;
+            messages: any;
+            disableWebhookGeneration: boolean;
+            model: any;
+            env: Env;
+        },
+        dataCallback: (data: any) => any,
+    ) {
+        if (!ctx.messages?.length) {
+            return new Response("No messages provided", { status: 400 });
+        }
+
+        return this.provider.handleStream(
+            {
+                systemPrompt: ctx.systemPrompt,
+                preprocessedContext: ctx.preprocessedContext,
+                maxTokens: ctx.maxTokens,
+                messages: ctx.messages,
+                model: ctx.model,
+                env: ctx.env,
+                disableWebhookGeneration: ctx.disableWebhookGeneration,
+            },
+            dataCallback,
+        );
+    }
+}

--- a/packages/server/services/__tests__/ChatService.test.ts
+++ b/packages/server/services/__tests__/ChatService.test.ts
@@ -227,24 +227,6 @@ describe('ChatService', () => {
       Response.json = originalResponseJson;
       localService.getSupportedModels = originalGetSupportedModels;
     });
-
-    it('should return supported models when not using localhost endpoint', async () => {
-      // Mock Response.json
-      const originalResponseJson = Response.json;
-      Response.json = vi.fn().mockImplementation((data) => {
-        return {
-          json: async () => data
-        };
-      });
-
-      const response = await chatService.getSupportedModels();
-      const data = await response.json();
-
-      expect(data).toEqual(SUPPORTED_MODELS);
-
-      // Restore Response.json
-      Response.json = originalResponseJson;
-    });
   });
 
   describe('handleChatRequest', () => {


### PR DESCRIPTION
- Removes hardcoded model support in favor of dynamic retrieval of models via API. 
- Overrides to OPENAI_API_KEY and OPENAI_API_ENDPOINT are no longer needed (though still possible).
- Remove redundant scripts
- Update README to reflect new behaviors

TODO:

- [ ] Fix test failures - Inject an env param in `ChatSdk.buildMessageChain` and globally mock `env.kv.get("supportedModels")`